### PR TITLE
Nitpicks

### DIFF
--- a/KZLinkedConsole/Extensions/NSTextView+Extensions.swift
+++ b/KZLinkedConsole/Extensions/NSTextView+Extensions.swift
@@ -28,10 +28,10 @@ extension NSTextView {
         
         if appDelegate.application!(NSApplication.sharedApplication(), openFile: filePath) {
             dispatch_async(dispatch_get_main_queue()) {
-            if  let textView = KZPluginHelper.editorTextView(inWindow: self.window),
-                let line = Int(lineNumber) where line >= 1 {
-                    self.scrollTextView(textView, toLine:line)
-            }
+                if  let textView = KZPluginHelper.editorTextView(inWindow: self.window),
+                    let line = Int(lineNumber) where line >= 1 {
+                        self.scrollTextView(textView, toLine:line)
+                }
             }
         }
     }

--- a/KZLinkedConsole/Helper/KZPluginHelper.swift
+++ b/KZLinkedConsole/Helper/KZPluginHelper.swift
@@ -77,7 +77,7 @@ extension KZPluginHelper {
     static func consoleTextView(inWindow window: NSWindow? = NSApp.mainWindow) -> NSTextView? {
         guard let contentView = window?.contentView,
         let consoleTextView = KZPluginHelper.getViewByClassName("IDEConsoleTextView", inContainer: contentView) as? NSTextView else {
-            return nil;
+            return nil
         }
         return consoleTextView
     }

--- a/KZLinkedConsole/Helper/KZPluginHelper.swift
+++ b/KZLinkedConsole/Helper/KZPluginHelper.swift
@@ -30,11 +30,7 @@ class KZPluginHelper {
                 return subview
             }
 
-            guard let view = getViewByClassName(name, inContainer: subview) else {
-                continue
-            }
-
-            if view.isKindOfClass(targetClass) {
+            if let view = getViewByClassName(name, inContainer: subview) {
                 return view
             }
         }

--- a/KZLinkedConsole/KZLinkedConsole.swift
+++ b/KZLinkedConsole/KZLinkedConsole.swift
@@ -27,7 +27,7 @@ class KZLinkedConsole: NSObject {
         self.bundle = bundle
 
         super.init()
-        center.addObserver(self, selector: Selector("didChange"), name: "IDEControlGroupDidChangeNotificationName", object: nil)
+        center.addObserver(self, selector: "didChange", name: "IDEControlGroupDidChangeNotificationName", object: nil)
     }
 
     deinit {
@@ -50,8 +50,8 @@ class KZLinkedConsole: NSObject {
         }
         
         do {
-            try storageClass.jr_swizzleMethod(Selector("fixAttributesInRange:"), withMethod: Selector("kz_fixAttributesInRange:"))
-            try textViewClass.jr_swizzleMethod(Selector("mouseDown:"), withMethod: Selector("kz_mouseDown:"))
+            try storageClass.jr_swizzleMethod("fixAttributesInRange:", withMethod: "kz_fixAttributesInRange:")
+            try textViewClass.jr_swizzleMethod("mouseDown:", withMethod: "kz_mouseDown:")
         }
         catch {
             Swift.print("Swizzling failed")


### PR DESCRIPTION
Not sure if you'll like all of these. You don't need `Selector("foo")` because it's `StringLiteralConvertible` but it's less explicit, so kind of a matter of taste there.

Same for changing the `guard let` to `if let`, but in that case it's simpler because you skip the additional check, and `getViewByClassName` always returns the correct class so it was effectively a nil check anyway.
