### PR TITLE
Search parent directories if the file is not found in the current workspace.

### DIFF
--- a/KZLinkedConsole/Extensions/NSTextView+Extensions.swift
+++ b/KZLinkedConsole/Extensions/NSTextView+Extensions.swift
@@ -30,7 +30,7 @@ extension NSTextView {
             return
         }
         
-        let args = [workspacePath, "-name", fileName, "-print", "-quit"]
+        let args = ["-L", workspacePath, "-name", fileName, "-print", "-quit"]
         guard let filePath = KZPluginHelper.runShellCommand("/usr/bin/find", arguments: args) else {
             return
         }

--- a/KZLinkedConsole/Extensions/NSTextView+Extensions.swift
+++ b/KZLinkedConsole/Extensions/NSTextView+Extensions.swift
@@ -30,7 +30,8 @@ extension NSTextView {
             return
         }
         
-        guard let filePath = KZPluginHelper.runShellCommand("find '\(workspacePath)' -name '\(fileName)' | head -n 1") else {
+        let args = [workspacePath, "-name", fileName, "-print", "-quit"]
+        guard let filePath = KZPluginHelper.runShellCommand("/usr/bin/find", arguments: args) else {
             return
         }
         

--- a/KZLinkedConsole/Helper/KZPluginHelper.swift
+++ b/KZLinkedConsole/Helper/KZPluginHelper.swift
@@ -7,11 +7,11 @@ import Foundation
 import AppKit
 
 class KZPluginHelper: NSObject {
-    static func runShellCommand(command: String) -> String? {
+    static func runShellCommand(launchPath: String, arguments: [String]) -> String? {
         let pipe = NSPipe()
         let task = NSTask()
-        task.launchPath = "/bin/sh"
-        task.arguments = ["-c", String(format: "%@", command)]
+        task.launchPath = launchPath
+        task.arguments = arguments
         task.standardOutput = pipe
         let file = pipe.fileHandleForReading
         task.launch()


### PR DESCRIPTION
If the file that we're looking for is not found in the current workspace, search the parent directory.  This will find the file if it is in a separate repo nearby to the current project.  This is easier than parsing the project's header and framework search paths, but hopefully will find the file in most cases.

This recursion stops if we have searched two levels up, or if we've reached the user's home directory.  This is to avoid performing searches that are too costly.

This PR also changes runShellCommand so that it doesn't use the shell.  This fixes a potentially serious security hole in the handling of the shell arguments, because the workspacePath and fileName were not escaped and were just passed to the shell verbatim.  To avoid using the shell at all, we can use -quit on the find command line, so there's no need for the pipe to head -n 1.

This PR also adds -L to the find command line.  This means that find will follow any symbolic links when looking for files.  If the user has repos that are symlinked into their workspace, this means that we'll find them now.
