### PR TITLE
Add a cache of looked-up filenames.

### DIFF
--- a/KZLinkedConsole/Extensions/NSTextView+Extensions.swift
+++ b/KZLinkedConsole/Extensions/NSTextView+Extensions.swift
@@ -30,7 +30,7 @@ extension NSTextView {
             return
         }
         
-        let args = [workspacePath, "-name", fileName, "-print", "-quit"]
+        let args = ["-L", workspacePath, "-name", fileName, "-print", "-quit"]
         guard let filePath = KZPluginHelper.runShellCommand("/usr/bin/find", arguments: args) else {
             return
         }

--- a/KZLinkedConsole/Extensions/NSTextView+Extensions.swift
+++ b/KZLinkedConsole/Extensions/NSTextView+Extensions.swift
@@ -30,7 +30,8 @@ extension NSTextView {
             return
         }
         
-        guard let filePath = KZPluginHelper.runShellCommand("find '\(workspacePath)' -name '\(fileName)' | head -n 1") else {
+        let args = [workspacePath, "-name", fileName, "-print", "-quit"]
+        guard let filePath = KZPluginHelper.runShellCommand("/usr/bin/find", arguments: args) else {
             return
         }
         

--- a/KZLinkedConsole/Helper/KZPluginHelper.swift
+++ b/KZLinkedConsole/Helper/KZPluginHelper.swift
@@ -7,11 +7,11 @@ import Foundation
 import AppKit
 
 class KZPluginHelper: NSObject {
-    static func runShellCommand(command: String) -> String? {
+    static func runShellCommand(launchPath: String, arguments: [String]) -> String? {
         let pipe = NSPipe()
         let task = NSTask()
-        task.launchPath = "/bin/sh"
-        task.arguments = ["-c", String(format: "%@", command)]
+        task.launchPath = launchPath
+        task.arguments = arguments
         task.standardOutput = pipe
         let file = pipe.fileHandleForReading
         task.launch()


### PR DESCRIPTION
This avoids performing the find every time.  This cache doesn't get cleared since there's not an easy hook for doing that.  To avoid permanently-bad cache entries, we at least check that the file still exists before returning that as a result.

This PR is dependent upon PR #14.
