### PR TITLE
Fix issue with SwiftyBeaver log format

### DIFF
--- a/KZLinkedConsole/Extensions/NSTextStorage+Extensions.swift
+++ b/KZLinkedConsole/Extensions/NSTextStorage+Extensions.swift
@@ -67,6 +67,6 @@ extension NSTextStorage {
         //
         // (If this gets any more complicated there will need to be a formal way to walk through multiple
         // patterns and check if each one matches.)
-        return try! NSRegularExpression(pattern: "([\\w\\+]+)\\.(\\w+)(\\(.*\\))?:(\\d+)", options: .CaseInsensitive)
+        return try! NSRegularExpression(pattern: "([\\w\\+]+)\\.(\\w+)(\\([^)]*\\))?:(\\d+)", options: .CaseInsensitive)
     }
 }

--- a/KZLinkedConsole/Extensions/NSTextStorage+Extensions.swift
+++ b/KZLinkedConsole/Extensions/NSTextStorage+Extensions.swift
@@ -67,6 +67,6 @@ extension NSTextStorage {
         //
         // (If this gets any more complicated there will need to be a formal way to walk through multiple
         // patterns and check if each one matches.)
-        return try! NSRegularExpression(pattern: "([\\w\\+]+)\\.(\\w+)(\\(\\))?:(\\d+)", options: .CaseInsensitive)
+        return try! NSRegularExpression(pattern: "([\\w\\+]+)\\.(\\w+)(\\(.*\\))?:(\\d+)", options: .CaseInsensitive)
     }
 }


### PR DESCRIPTION
This solves the issue I have reported (#16). I just modified the regular expression that was parsing the line in the log.
<img width="1231" alt="screen shot 2016-01-03 at 13 10 28" src="https://cloud.githubusercontent.com/assets/715405/12078695/2404a9d2-b21c-11e5-80ae-ee9733fc7d22.png">

Now it is working in the example I posted in the issue.
<img width="983" alt="screen shot 2016-01-03 at 13 13 04" src="https://cloud.githubusercontent.com/assets/715405/12078700/4d71ec1c-b21c-11e5-8cee-bc83d55f82da.png">
